### PR TITLE
Update CMakeLists.txt c++ version flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ set (fasttext_VERSION_MINOR 1)
 
 include_directories(fasttext)
 
-set(CMAKE_CXX_FLAGS " -pthread -std=c++11 -funroll-loops -O3 -march=native")
+set(CMAKE_CXX_FLAGS " -pthread -std=c++17 -funroll-loops -O3 -march=native")
 
 set(HEADER_FILES
     src/args.h


### PR DESCRIPTION
Bump `-std=c++11` to 17 to avoid errors like `error: ‘string_view’ in namespace ‘std’ does not name a type` and related `note: ‘std::string_view’ is only available from C++17 onwards`